### PR TITLE
replace deprecated $.parseJSON() with JSON.parse().

### DIFF
--- a/jquery.plugin.js
+++ b/jquery.plugin.js
@@ -217,7 +217,7 @@
 					var count = data.substring(0, i).match(/"/g); // Handle embedded ':'
 					return (!count || count.length % 2 === 0 ? '"' + group + '":' : group + ':');
 				});
-				data = $.parseJSON('{' + data + '}');
+				data = JSON.parse('{' + data + '}');
 				for (var name in data) { // Convert dates
 					var value = data[name];
 					if (typeof value === 'string' && value.match(/^new Date\((.*)\)$/)) {


### PR DESCRIPTION
parseJSON() is deprecated from jquery version 3.  JSON.parse() is supported by IE 8 and above.
